### PR TITLE
Handle httpc socket_closed_remotely error

### DIFF
--- a/src/emq_auth_http_cli.erl
+++ b/src/emq_auth_http_cli.erl
@@ -35,7 +35,8 @@ request(post, Url, Params) ->
 request_(Method, Req, HTTPOpts, Opts, Times) ->
     %% Resend request, when TCP closed by remotely
     case httpc:request(Method, Req, HTTPOpts, Opts) of
-        {error, socket_closed_remotely} when Times < 5 ->
+        {error, socket_closed_remotely} when Times < 3 ->
+            timer:sleep(trunc(math:pow(10, Times))),
             request_(Method, Req, HTTPOpts, Opts, Times+1);
         Other -> Other
     end.


### PR DESCRIPTION
For fixing issue #70.

The error will occur when httpc send HTTP Request by a half-closed TCP Connection

tcpdump illustration:
```
Client ----------- SYN --------> Server
Client <------- SYN,ACK -------> Server
Client <--------- ACK ---------- Server

      (ESTABLISHED TCP CONNECTION)

Client ======= HTTP Reqs ====> Server
Client <====== HTTP Resp ===== Server

      (Multiple Transmission...)

Client ======= HTTP Reqs ====> Server
Client <====== HTTP Resp ===== Server

Client <---------- FIN --------- Server
Client ----------- ACK --------> Server
Client ======== HTTP Reqs ======> Server
Client <---------- RST --------- Server
```