### PR TITLE
ignore auth on ignore in body, allows for chaining methods

### DIFF
--- a/src/emq_acl_http.erl
+++ b/src/emq_acl_http.erl
@@ -35,6 +35,7 @@ init(AclReq) ->
 check_acl({Client, PubSub, Topic}, #state{acl_req = #http_request{method = Method, url = Url, params = Params}}) ->
     Params1 = feedvar(feedvar(feedvar(Params, Client), "%A", access(PubSub)), "%t", Topic),
     case request(Method, Url, Params1) of
+        {ok, 200, "ignore"} -> ignore;
         {ok, 200, _Body}   -> allow;
         {ok, _Code, _Body} -> deny;
         {error, Error}     -> lager:error("Http check_acl url ~s Error: ~p", [Url, Error]), deny

--- a/src/emq_auth_http.erl
+++ b/src/emq_auth_http.erl
@@ -38,6 +38,7 @@ check(#mqtt_client{username = Username}, Password, _Env) when ?UNDEFINED(Usernam
 check(Client, Password, {#http_request{method = Method, url = Url, params = Params}, SuperReq}) ->
     Params1 = feedvar(feedvar(Params, Client), "%P", Password),
     case request(Method, Url, Params1) of
+        {ok, 200, "ignore"} -> ignore;
         {ok, 200, _Body}  -> {ok, is_superuser(SuperReq, Client)};
         {ok, Code, _Body} -> {error, Code};
         {error, Error}    -> lager:error("HTTP ~s Error: ~p", [Url, Error]),


### PR DESCRIPTION
At present, authentication delegation chain is broken when involving emq-auth-http. This allows the http authentication server to explicitly delegate authentication to the next authentication plugin in the chain by returning a specific "ignore" string in the response body.